### PR TITLE
ci: cut GitHub Actions job runs by ~58%

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -15,8 +15,9 @@ permissions:
 
 jobs:
   auto-assign:
-    # Bot-opened PRs (Renovate, Dependabot) already carry assignees from
-    # renovate.json, so assigning them again is a wasted run per dependency bump.
+    # Skip bot-opened issues and pull requests. Renovate PRs already carry
+    # assignees from renovate.json, and its Dependency Dashboard issue doesn't
+    # need one — so every bot event here is a wasted run per dependency bump.
     if: github.event.sender.type != 'Bot'
     runs-on: self-hosted
     steps:

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -15,6 +15,9 @@ permissions:
 
 jobs:
   auto-assign:
+    # Bot-opened PRs (Renovate, Dependabot) already carry assignees from
+    # renovate.json, so assigning them again is a wasted run per dependency bump.
+    if: github.event.sender.type != 'Bot'
     runs-on: self-hosted
     steps:
       # Assign the securehst account to every newly-opened issue and pull request

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,14 +35,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # No `os` axis: every job runs on the same Linux self-hosted runner, so a
+        # matrix over ubuntu/windows/macOS produced 3x identical jobs per Python
+        # version. Restore it only alongside `runs-on: ${{ matrix.os }}` and
+        # GitHub-hosted runners.
         python-version:
           - "3.11"
           - "3.12"
           - "3.13"
-        os:
-          - ubuntu-latest
-          - windows-latest
-          - macOS-latest
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -65,6 +65,10 @@ jobs:
       - lint
       - commitlint
 
+    # Only on a merge to main. Previously this job also spun up on every PR just
+    # to run a PSR `--noop` dry run, which meant a full release job per PR.
+    if: github.event_name == 'push' && github.ref_name == 'main'
+
     runs-on: self-hosted
     environment: release
     concurrency: release
@@ -80,19 +84,11 @@ jobs:
           fetch-tags: true
           ref: main
 
-      # Do a dry run of PSR
-      - name: Test release
-        uses: python-semantic-release/python-semantic-release@39dd2052f2ce8282a5d932c31d58a2ca06d2550e # v10
-        if: github.ref_name != 'main'
-        with:
-          root_options: --noop
-          github_token: noop
-
-      # On main branch: actual PSR + upload to PyPI & GitHub
+      # Actual PSR + upload to PyPI & GitHub. The job-level `if` already
+      # restricts this to pushes on main.
       - name: Release
         uses: python-semantic-release/python-semantic-release@39dd2052f2ce8282a5d932c31d58a2ca06d2550e # v10
         id: release
-        if: github.ref_name == 'main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/issue-manager.yml
+++ b/.github/workflows/issue-manager.yml
@@ -1,17 +1,12 @@
 name: Issue Manager
 
 on:
+  # Weekly is enough: the script does a full repo-wide sweep for the labels in
+  # CONFIG below, and the shortest delay it enforces is 10 days. The old
+  # issue_comment / issues:labeled / pull_request_target:labeled triggers ran the
+  # same sweep on every label and comment event, which the sweep already covers.
   schedule:
-    - cron: "0 0 * * *"
-  issue_comment:
-    types:
-      - created
-  issues:
-    types:
-      - labeled
-  pull_request_target:
-    types:
-      - labeled
+    - cron: "0 0 * * 1"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -5,7 +5,9 @@ on:
     branches:
       - main
     paths:
-      - ".github/**"
+      # Only the label config matters here — ".github/**" re-synced labels on
+      # every workflow file change.
+      - ".github/labels.toml"
 
 jobs:
   labels:


### PR DESCRIPTION
## Summary

This repo runs **1,676 Actions jobs / 717 wall-minutes per 30 days** — the highest of any repo in the account. Most of it is redundant. These four changes cut it to roughly **708 jobs / 340 minutes (−58% jobs, −53% minutes)** with no loss of real coverage.

Measured from job-level API data across all 297 workflow runs in the trailing 30 days.

## Changes

| Commit | Change | Jobs saved / 30d |
|---|---|---|
| `30ab18d` | Drop the phantom `os` matrix axis in CI | −756 |
| `30ab18d` | Gate `release` to pushes on `main` | −76 |
| `37766fa` | Issue Manager: schedule + dispatch only, weekly | −75 |
| `8b7efb7` | Auto Assign: skip bot-opened issues/PRs | −30 |
| `8cefad1` | Label sync: narrow path filter to `labels.toml` | −31 |
| `0a73a9b` | Comment-only: clarify the auto-assign bot-skip condition | — |

### The big one: the OS matrix was never real

`ci.yml` declared a 3 Python × 3 OS matrix, but the job pins `runs-on: self-hosted`. The `os` axis was never applied — all nine jobs ran on the same Linux runner and produced identical results under misleading names (`test (3.11, windows-latest)` was Linux). Six of every nine test jobs were exact duplicates: **756 of 1,134 test job runs in 30 days.**

Restoring per-OS testing means adding `runs-on: ${{ matrix.os }}` and GitHub-hosted runners; there's a comment in the matrix noting this so it isn't re-added without the wiring.

## Behavior changes worth reviewing

- **Stale-issue closes shift to 10–17 days** after labeling (was 10–11), since a weekly sweep can miss the exact day the 10-day delay elapses.

The PR-time PSR dry run is **not** a real loss. The `Test release` step ran *after* a `checkout` with `ref: main`, so on a pull request it `--noop`'d against main's release config, never the PR's. It could not have caught a broken release config introduced by the PR under review. Removing it drops a full `release` job (plus its `test` + `lint` + `commitlint` dependencies) per PR and gives up nothing.

## Verification

- `actionlint` clean on all workflows
- Full `pre-commit` suite passes on the changed files (`check-yaml`, `prettier`, `codespell`)
- All commits pass the `commitizen` commit-msg hook
- `ci:` is in `exclude_commit_patterns`, so this triggers no version bump or changelog entry

## Review notes

**`release` checks out `ref: main` rather than the triggering SHA.** Raised in review; deliberately unchanged here.

- The line predates this PR and is untouched by the diff. `main` already carried `if: github.ref_name == 'main'` on the `Release` step, so the actual release path is identical before and after — this PR only stops the *job* from spinning up on pull requests.
- Checking out `${{ github.sha }}` instead would break releases. `pyproject.toml` sets `[tool.semantic_release.branches.main] match = "main"`; PSR resolves the *active branch name* to select a release config, and pushes the version-bump commit and tag back to it. A SHA checkout is detached HEAD, which defeats both.
- The residual drift is narrow: if two merges land close together both runs check out the same tip, the first releases it, and the second finds no commits since the tag and no-ops. The real exposure — releasing a commit whose own CI hasn't finished — exists independently of this change, since `main` has no branch protection.

Closing it properly means a separate guard step (skip the release when `git rev-parse HEAD != github.sha`, letting the newer run handle it), not a change to this PR.

## Not included

1. **The 9.5 GB pre-commit cache** (12 caches × ~900 MB, against a 10 GB limit). `pre-commit/action` has no flag to disable its internal `actions/cache`, so fixing this means replacing the action with a plain `pip install pre-commit` and letting the self-hosted runner keep `~/.cache/pre-commit` on local disk. This is why `lint` is the slowest CI job at ~55s/run — it ships ~900 MB over the wire to a runner that already has the files.
2. **A pre-push hook bug** — `scripts/check_remote_updates.sh` runs `git rev-parse origin/$BRANCH` under `set -e`, which always exits 128 for a branch not yet on the remote. It blocks the first push of every new branch.
3. **Dead PSR config** — `[tool.semantic_release.branches.noop]` in `pyproject.toml` existed to serve the removed dry run, and was never reached even then (the dry run's active branch was always `main`, so it matched `branches.main`). Harmless to leave; a clean follow-up to drop.

Renovate throttling was previously listed here as the largest remaining lever. It has since landed separately in #268 (`schedule`, `rebaseWhen: conflicted`, `minimumReleaseAge`, with `vulnerabilityAlerts` exempted), so this branch will want a rebase on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
