### PR TITLE
chore: batch Renovate into a weekly window, ignore RUNME.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,7 @@ cython_debug/
 
 # Pycharm Files
 .idea/
+
+# Local scratch invocation notes. These hold real API keys and project paths,
+# so they must never be committed — this repo is public.
+RUNME.md

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,10 @@
     "github>browniebroke/renovate-configs:python",
     "config:recommended"
   ],
+  "description": [
+    "Dependency updates are batched into a single weekly window. Renovate drove 92 of 126 CI runs over a 30-day sample; with one self-hosted runner executing jobs serially, that churn is the dominant source of CI latency in this repo.",
+    "Security updates deliberately bypass every throttle below - see vulnerabilityAlerts."
+  ],
   "reviewers": ["securehst"],
   "assignees": ["securehst"],
   "automerge": true,
@@ -11,7 +15,15 @@
   "platformAutomerge": true,
   "prHourlyLimit": 2,
   "prConcurrentLimit": 5,
-  "rebaseWhen": "behind-base-branch",
+  "schedule": ["before 4am on monday"],
+  "minimumReleaseAge": "3 days",
+  "rebaseWhen": "conflicted",
+  "vulnerabilityAlerts": {
+    "description": "Security fixes ignore the weekly window and the release-age delay, and open immediately.",
+    "schedule": ["at any time"],
+    "minimumReleaseAge": null,
+    "prCreation": "immediate"
+  },
   "packageRules": [
     {
       "matchManagers": ["uv"],


### PR DESCRIPTION
## Summary

Two independent commits. The Renovate change is the largest remaining lever on CI usage; the `.gitignore` change closes a path to publishing a live API key.

## `chore: batch renovate updates into a weekly window`

Renovate triggered **92 of 126 CI runs** over a 30-day sample. With a single self-hosted runner executing jobs serially, that churn is the main source of CI latency, not merely job count.

Sampling the last 25 Renovate PRs makes the pattern concrete — **10 were digest bumps to `anthropics/claude-code-action` alone**, one PR and one full CI run per upstream commit:

```
264  chore(deps): update anthropics/claude-code-action digest to fa7e2f0
261  chore(deps): update anthropics/claude-code-action digest to b76a077
257  chore(deps): update anthropics/claude-code-action digest to af0559e
256  chore(deps): update anthropics/claude-code-action digest to 3553f84
254  chore(deps): update anthropics/claude-code-action digest to 700e7f8
...
```

Three changes:

| Setting | Was | Now | Effect |
|---|---|---|---|
| `schedule` | *(none — continuous)* | `before 4am on monday` | A week of updates collapses into one grouped PR per manager |
| `rebaseWhen` | `behind-base-branch` | `conflicted` | Stops the rebase cascade |
| `minimumReleaseAge` | *(none)* | `3 days` | Rapid-fire patch releases collapse into one update |

**On `rebaseWhen`:** the old value rebased every open PR on each merge to `main`, re-triggering CI on each one. Combined with `automerge` and `prConcurrentLimit: 5` this cascaded — merge one, rebase four, each re-runs CI, each then automerges, repeat.

**Security updates bypass all three**, via an explicit `vulnerabilityAlerts` block. Renovate's defaults already behave this way; stating it in the config keeps the security posture readable next to the delays it overrides, and pins it against upstream default changes.

### Tradeoffs worth your judgement

- **Dependency updates land up to a week later**, plus the 3-day release-age delay. Security fixes are exempt.
- **`rebaseWhen: conflicted` means a PR can merge while behind `main`** without re-running CI against the latest tip. Low risk for dependency bumps, and if you want a hard guarantee, enable *"Require branches to be up to date before merging"* in branch protection — that enforces it at the gate rather than by burning a CI run on every open PR.

## `chore: ignore RUNME.md`

`RUNME.md` holds a scratch CLI invocation including a **live OpenAI API key** and a local path. It has never been tracked, but this repo is public and a single `git add -A` would publish it.

**Ignoring the file does not protect the key already in it — that key is live and still needs rotating.**

## Verification

`renovate-config-validator` **43.275.1** (current) — passes as repo config.

Validation was confirmed to be meaningful rather than a no-op: feeding it a deliberately malformed schedule (`before 4am on funday`) produces `Invalid schedule: Failed to parse`, so the accepted schedule string was genuinely parsed.

## Related

Independent of #265 (Actions usage) and #267 (pre-push hook). Merge in any order.

Expected combined effect with #265: roughly **−85%** on Actions job runs versus the 30-day baseline of 1,676 jobs / 717 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)